### PR TITLE
fmt/ass: don't bail on Graphics and Fonts sections

### DIFF
--- a/bubblesub/fmt/ass/reader.py
+++ b/bubblesub/fmt/ass/reader.py
@@ -210,7 +210,11 @@ def load_ass(handle: T.IO[str], ass_file: AssFile) -> None:
                     handler = _styles_section_handler
                 elif section == "Events":
                     handler = _events_section_handler
-                elif section == "Aegisub Project Garbage":
+                elif section in [
+                    "Aegisub Project Garbage",
+                    "Graphics",
+                    "Fonts",
+                ]:
                     handler = _dummy_handler
                 else:
                     raise ValueError(f'unrecognized section: "{section}"')


### PR DESCRIPTION
There's really no reason to throw an error for these being present.